### PR TITLE
NodeMapper added

### DIFF
--- a/core/src/main/java/com/turkraft/springfilter/parser/ParseContext.java
+++ b/core/src/main/java/com/turkraft/springfilter/parser/ParseContext.java
@@ -1,10 +1,15 @@
 package com.turkraft.springfilter.parser;
 
+import com.turkraft.springfilter.parser.node.FilterNode;
 import java.util.function.UnaryOperator;
 
 public interface ParseContext {
 
   default UnaryOperator<String> getFieldMapper() {
+    return UnaryOperator.identity();
+  }
+
+  default UnaryOperator<FilterNode> getNodeMapper() {
     return UnaryOperator.identity();
   }
 

--- a/core/src/main/java/com/turkraft/springfilter/parser/ParseContextImpl.java
+++ b/core/src/main/java/com/turkraft/springfilter/parser/ParseContextImpl.java
@@ -1,18 +1,52 @@
 package com.turkraft.springfilter.parser;
 
+import com.turkraft.springfilter.parser.node.FilterNode;
 import java.util.function.UnaryOperator;
+import org.springframework.lang.Nullable;
 
 public class ParseContextImpl implements ParseContext {
 
-  private final UnaryOperator<String> fieldMapper;
+  private UnaryOperator<String> fieldMapper;
 
-  public ParseContextImpl(UnaryOperator<String> fieldMapper) {
+  private UnaryOperator<FilterNode> nodeMapper;
+
+  public ParseContextImpl() {
+  }
+
+  public ParseContextImpl(@Nullable UnaryOperator<String> fieldMapper,
+      @Nullable UnaryOperator<FilterNode> nodeMapper) {
+    this.fieldMapper = fieldMapper;
+    this.nodeMapper = nodeMapper;
+  }
+
+  @Deprecated(since = "3.1.3")
+  public ParseContextImpl(@Nullable UnaryOperator<String> fieldMapper) {
     this.fieldMapper = fieldMapper;
   }
 
   @Override
   public UnaryOperator<String> getFieldMapper() {
+    if (fieldMapper == null) {
+      return UnaryOperator.identity();
+    }
     return fieldMapper;
+  }
+
+  public void setFieldMapper(UnaryOperator<String> fieldMapper) {
+    this.fieldMapper = fieldMapper;
+  }
+
+  @Override
+  public UnaryOperator<FilterNode> getNodeMapper() {
+    if (nodeMapper == null) {
+      return UnaryOperator.identity();
+    }
+    return nodeMapper;
+  }
+
+  public void setNodeMapper(
+      UnaryOperator<FilterNode> nodeMapper) {
+    this.nodeMapper = nodeMapper;
   }
 
 }

--- a/core/src/test/java/com/turkraft/springfilter/NodeMapperTest.java
+++ b/core/src/test/java/com/turkraft/springfilter/NodeMapperTest.java
@@ -1,9 +1,12 @@
 package com.turkraft.springfilter;
 
 import com.turkraft.springfilter.converter.FilterStringConverter;
+import com.turkraft.springfilter.language.EqualOperator;
+import com.turkraft.springfilter.language.NotEqualOperator;
 import com.turkraft.springfilter.parser.FilterParser;
 import com.turkraft.springfilter.parser.ParseContextImpl;
 import com.turkraft.springfilter.parser.node.FilterNode;
+import com.turkraft.springfilter.parser.node.InfixOperationNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-public class FieldMapperTest {
+public class NodeMapperTest {
 
   @Configuration
   @ComponentScan("com.turkraft.springfilter")
@@ -27,17 +30,31 @@ public class FieldMapperTest {
   @Autowired
   private FilterStringConverter filterStringConverter;
 
+  @Autowired
+  private EqualOperator equalOperator;
+
+  @Autowired
+  private NotEqualOperator notEqualOperator;
+
   @Test
   void test() {
 
     ParseContextImpl ctx = new ParseContextImpl();
-    ctx.setFieldMapper(
-        (String field) -> field.equalsIgnoreCase("x") ? "a"
-            : field.equalsIgnoreCase("y") ? "b" : field);
-    
+    ctx.setNodeMapper(
+        (FilterNode node) -> {
+          if (node instanceof InfixOperationNode op) {
+            if (op.getOperator() == equalOperator) {
+              return new InfixOperationNode(op.getLeft(), notEqualOperator, op.getRight());
+            } else if (op.getOperator() == notEqualOperator) {
+              return new InfixOperationNode(op.getLeft(), equalOperator, op.getRight());
+            }
+          }
+          return null;
+        });
+
     FilterNode node = filterParser.parse("x : y : z", ctx);
 
-    Assertions.assertEquals("a : b : z", filterStringConverter.convert(node));
+    Assertions.assertEquals("x ! y ! z", filterStringConverter.convert(node));
 
   }
 


### PR DESCRIPTION
Added ability to map parsed nodes:

```java
ParseContextImpl ctx = new ParseContextImpl();
ctx.setNodeMapper(
    (FilterNode node) -> {
      // invert equals and not equals
      if (node instanceof InfixOperationNode op) {
        if (op.getOperator() == equalOperator) {
          return new InfixOperationNode(op.getLeft(), notEqualOperator, op.getRight());
        } else if (op.getOperator() == notEqualOperator) {
          return new InfixOperationNode(op.getLeft(), equalOperator, op.getRight());
        }
      }
      return null;
    });

FilterNode node = filterParser.parse("x : y ! z", ctx);

Assertions.assertEquals("x ! y : z", filterStringConverter.convert(node));
```