### PR TITLE
Escaping % and *

### DIFF
--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LikeOperationExpressionProcessor.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LikeOperationExpressionProcessor.java
@@ -44,7 +44,15 @@ public class LikeOperationExpressionProcessor implements
       return (Expression<String>) transformer.transform(node);
     }
 
-    String pattern = ((InputNode) node).getValue().toString().replace("*", "%");
+    String pattern = ((InputNode) node).getValue().toString();
+
+    pattern = pattern.replace("\\\\%", "\\%");
+
+    pattern = pattern.replace("\\\\*", "X_ESCAPED_STAR_X");
+
+    pattern = pattern.replace("*", "%");
+
+    pattern = pattern.replace("X_ESCAPED_STAR_X", "*");
 
     if (!pattern.contains("%")) {
       pattern = "%" + pattern + "%";


### PR DESCRIPTION
Fixes #305

`%` can be escaped with `\\%` and `*` can be escaped with `\\*` .