### PR TITLE
Added ListExpression as an alternative to cb.in('...')

### DIFF
--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/ConvertibleExpression.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/ConvertibleExpression.java
@@ -1,0 +1,9 @@
+package com.turkraft.springfilter.transformer;
+
+import jakarta.persistence.criteria.Expression;
+
+public interface ConvertibleExpression {
+
+  Expression<?> convertTo(Class<?> type);
+
+}

--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/FilterExpressionTransformer.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/FilterExpressionTransformer.java
@@ -141,6 +141,9 @@ public class FilterExpressionTransformer implements FilterNodeTransformer<Expres
   }
 
   private Expression<?> castIfNeeded(Expression<?> expression, @Nullable Class<?> targetType) {
+    if (targetType != null && expression instanceof ConvertibleExpression convertibleExpression) {
+      return convertibleExpression.convertTo(targetType);
+    }
     if (targetType != null && expression.getJavaType() != null
         && !targetType.isAssignableFrom(expression.getJavaType())) {
       return expression.as(targetType);

--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/ListExpression.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/ListExpression.java
@@ -1,0 +1,94 @@
+package com.turkraft.springfilter.transformer;
+
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Selection;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ListExpression<T> implements Expression<T>, ConvertibleExpression {
+
+  private List<Expression<T>> values;
+
+  public ListExpression(List<Expression<T>> values) {
+    this.values = values;
+  }
+
+  public List<Expression<T>> getValues() {
+    return values;
+  }
+
+  public void setValues(List<Expression<T>> values) {
+    this.values = values;
+  }
+
+  @Override
+  public Predicate isNull() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Predicate isNotNull() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Predicate in(Object... values) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Predicate in(Expression<?>... values) {
+    return null;
+  }
+
+  @Override
+  public Predicate in(Collection<?> values) {
+    return null;
+  }
+
+  @Override
+  public Predicate in(Expression<Collection<?>> values) {
+    return null;
+  }
+
+  @Override
+  public <X> Expression<X> as(Class<X> type) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Selection<T> alias(String name) {
+    return null;
+  }
+
+  @Override
+  public boolean isCompoundSelection() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<Selection<?>> getCompoundSelectionItems() {
+    return null;
+  }
+
+  @Override
+  public Class<? extends T> getJavaType() {
+    return null;
+  }
+
+  @Override
+  public String getAlias() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Expression<T> convertTo(Class<?> type) {
+    return new ListExpression(values.stream().map(
+        v -> v != null && v.getJavaType() != null && !type.isAssignableFrom(v.getJavaType()) ? v.as(
+            type) : v).collect(
+        Collectors.toList()));
+  }
+
+}

--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/InOperationExpressionProcessor.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/InOperationExpressionProcessor.java
@@ -5,6 +5,7 @@ import com.turkraft.springfilter.parser.node.CollectionNode;
 import com.turkraft.springfilter.parser.node.FilterNode;
 import com.turkraft.springfilter.parser.node.InfixOperationNode;
 import com.turkraft.springfilter.transformer.FilterExpressionTransformer;
+import com.turkraft.springfilter.transformer.ListExpression;
 import jakarta.persistence.criteria.CriteriaBuilder.In;
 import jakarta.persistence.criteria.Expression;
 import org.springframework.stereotype.Component;
@@ -47,8 +48,22 @@ public class InOperationExpressionProcessor implements
 
     transformer.registerTargetType(source.getRight(), left.getJavaType());
 
+    Expression<?> right = transformer.transform(source.getRight());
+
+    if (right instanceof ListExpression<?> listExpression) {
+
+      In<Object> in = transformer.getCriteriaBuilder().in(left);
+
+      for (Expression<?> value : listExpression.getValues()) {
+        in.value(value);
+      }
+
+      return in;
+
+    }
+
     return transformer.getCriteriaBuilder().in(left)
-        .value((Expression) transformer.transform(source.getRight()));
+        .value((Expression) right);
 
   }
 


### PR DESCRIPTION
A transformer can now return a ListExpression which will be properly used with the filter's `in` operator.
Ref: https://stackoverflow.com/questions/9321916/jpa-criteriabuilder-how-to-use-in-comparison-operator