### PR TITLE
fix: Lower Function and exception typo

### DIFF
--- a/core/src/main/java/com/turkraft/springfilter/parser/node/FunctionNode.java
+++ b/core/src/main/java/com/turkraft/springfilter/parser/node/FunctionNode.java
@@ -36,7 +36,7 @@ public class FunctionNode extends FilterNode {
 
   public FilterNode getArgument(int index) {
     return getArgument(index,
-        "The function `" + filterFunction.getName() + "` expects at least " + index
+        "The function `" + filterFunction.getName() + "` expects at least " + (index + 1)
             + " argument(s)");
   }
 

--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LowerFunctionExpressionProcessor.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LowerFunctionExpressionProcessor.java
@@ -25,7 +25,7 @@ public class LowerFunctionExpressionProcessor implements
   @Override
   public Expression<?> process(FilterExpressionTransformer transformer,
       FunctionNode source) {
-    transformer.registerTargetType(source.getArgument(1), String.class);
+    transformer.registerTargetType(source.getArgument(0), String.class);
     return transformer.getCriteriaBuilder()
         .lower((Expression<String>) transformer.transform(source.getArgument(0)));
   }


### PR DESCRIPTION
This PR addresses an error with LowerFunctionExpressionProcessor, in which the registered target type of the function was the 2' argument (index = 1) instead of the first argument (index = 0).
This was forcing to write queries like the below one
`lower(name, '') ~ 'example'`
Instead of 
`lower(name) ~ 'example'`.

This PR resolves also a typo when an argument exception occurs: the argument at index position is the (index+1)th argument 