### PR TITLE
fix: unescape backslashes before sending to the database

### DIFF
--- a/core/src/main/java/com/turkraft/springfilter/parser/AntlrParser.java
+++ b/core/src/main/java/com/turkraft/springfilter/parser/AntlrParser.java
@@ -57,7 +57,7 @@ class AntlrParser {
       String text = antlrCtx.getText().startsWith("'") && antlrCtx.getText().endsWith("'")
           ? antlrCtx.getText().substring(1, antlrCtx.getText().length() - 1)
           : antlrCtx.getText();
-      return map(ctx, new InputNode(text.replace("\\'", "'")));
+      return map(ctx, new InputNode(unescapeString(text)));
     }
 
     if (antlrCtx instanceof FieldContext) {
@@ -149,6 +149,10 @@ class AntlrParser {
       return input;
     }
     return Objects.requireNonNullElse(ctx.getNodeMapper().apply(input), input);
+  }
+
+  private String unescapeString(String input) {
+    return input.replace("\\'", "'").replace("\\\\", "\\");
   }
 
 }

--- a/core/src/main/java/com/turkraft/springfilter/parser/node/FunctionNode.java
+++ b/core/src/main/java/com/turkraft/springfilter/parser/node/FunctionNode.java
@@ -36,7 +36,7 @@ public class FunctionNode extends FilterNode {
 
   public FilterNode getArgument(int index) {
     return getArgument(index,
-        "The function `" + filterFunction.getName() + "` expects at least " + index
+        "The function `" + filterFunction.getName() + "` expects at least " + (index + 1)
             + " argument(s)");
   }
 

--- a/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LowerFunctionExpressionProcessor.java
+++ b/jpa/src/main/java/com/turkraft/springfilter/transformer/processor/LowerFunctionExpressionProcessor.java
@@ -25,7 +25,7 @@ public class LowerFunctionExpressionProcessor implements
   @Override
   public Expression<?> process(FilterExpressionTransformer transformer,
       FunctionNode source) {
-    transformer.registerTargetType(source.getArgument(1), String.class);
+    transformer.registerTargetType(source.getArgument(0), String.class);
     return transformer.getCriteriaBuilder()
         .lower((Expression<String>) transformer.transform(source.getArgument(0)));
   }


### PR DESCRIPTION
resolves #382 
blocked by #443 

Query `description~'\\'` is now sent to the database with only one backslash, because the first backslash is the escape for the second one